### PR TITLE
Review of pr-578 and proposed changes

### DIFF
--- a/common/scala/src/whisk/core/connector/Message.scala
+++ b/common/scala/src/whisk/core/connector/Message.scala
@@ -19,12 +19,7 @@ package whisk.core.connector
 import scala.util.Try
 
 import spray.json.DefaultJsonProtocol
-import spray.json.JsNumber
 import spray.json.JsObject
-import spray.json.JsValue
-import spray.json.RootJsonFormat
-import spray.json.deserializationError
-import spray.json.pimpAny
 import spray.json.pimpString
 import whisk.common.TransactionId
 import whisk.core.entity.ActivationId
@@ -92,14 +87,13 @@ object ActivationMessage extends DefaultJsonProtocol {
  */
 case class CompletionMessage(
     override val transid: TransactionId,
-    activationId: ActivationId,
     response: WhiskActivation)
     extends Message {
 
     override def serialize = CompletionMessage.serdes.write(this).compactPrint
 
     override def toString = {
-        s"$activationId"
+        s"${response.activationId}"
     }
 }
 
@@ -109,5 +103,5 @@ object CompletionMessage extends DefaultJsonProtocol {
         serdes.read(msg.parseJson)
     }
 
-    implicit val serdes = jsonFormat3(CompletionMessage.apply)
+    implicit val serdes = jsonFormat2(CompletionMessage.apply)
 }

--- a/common/scala/src/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/whisk/core/entity/WhiskActivation.scala
@@ -21,6 +21,8 @@ import java.time.Instant
 import scala.util.Try
 
 import spray.json.DefaultJsonProtocol
+import spray.json.DefaultJsonProtocol.JsValueFormat
+import spray.json.DefaultJsonProtocol.optionFormat
 import spray.json.JsNumber
 import spray.json.JsObject
 import spray.json.JsString
@@ -71,7 +73,6 @@ case class WhiskActivation(
     require(start != null, "start undefined")
     require(end != null, "end undefined")
     require(response != null, "response undefined")
-    require(logs != null, "logs undefined")
 
     def toJson = WhiskActivation.serdes.write(this).asJsObject
 
@@ -80,30 +81,27 @@ case class WhiskActivation(
         JsObject(fields + ("activationId" -> activationId.toJson))
     }
 
-    def toExtendedJson : JsObject = {
+    def resultAsJson = response.result.toJson.asJsObject
+
+    def toExtendedJson = {
         val JsObject(baseFields) = WhiskActivation.serdes.write(this).asJsObject
         val newFields = (baseFields - "response") + ("response" -> response.toExtendedJson)
         JsObject(newFields)
     }
 
-    def getResultJson : JsObject = {
-        response.getResultJson
-    }
-
-    def stripLogs : WhiskActivation =
-        WhiskActivation(
-            namespace = namespace,
-            name = name,
-            subject = subject,
-            activationId = activationId,
-            start = start,
-            end = end,
-            cause = cause,
-            response = response,
-            logs = ActivationLogs(),
-            version = version,
-            publish = publish,
-            annotations = annotations)
+    def withoutLogs = WhiskActivation(
+        namespace = namespace,
+        name = name,
+        subject = subject,
+        activationId = activationId,
+        start = start,
+        end = end,
+        cause = cause,
+        response = response,
+        logs = ActivationLogs(),
+        version = version,
+        publish = publish,
+        annotations = annotations)
 }
 
 object WhiskActivation

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -15,7 +15,7 @@ sourceSets {
         scala {
             // This does not work because this project cannot use that project reference
             // srcDirs = ['src/'].plus(project(':core:loadbalancer').sourceSets.main.scala.srcDirs)
-            srcDirs = ['src/'].plus('../loadBalancer/src/').plus('../dispatcher/src/')
+            srcDirs = ['src/'].plus('../loadBalancer/src/')
             exclude 'resources/**'
         }
         resources {

--- a/core/controller/src/whisk/core/controller/Actions.scala
+++ b/core/controller/src/whisk/core/controller/Actions.scala
@@ -21,6 +21,7 @@ import scala.concurrent.Promise
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration.DurationInt
 import scala.collection.concurrent.TrieMap
+import scala.language.postfixOps
 import scala.util.Try
 import scala.util.Failure
 import scala.util.Success
@@ -51,8 +52,10 @@ import spray.json.JsString
 import spray.json.JsObject
 import spray.json.pimpString
 import spray.json.pimpAny
+import spray.routing.RequestContext
 import whisk.common.ConsulKV
 import whisk.common.ConsulKV.LoadBalancerKeys
+import whisk.common.LoggingMarkers
 import whisk.common.LoggingMarkers._
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
@@ -91,9 +94,7 @@ import whisk.core.entity.Subject
 import whisk.core.entity.WhiskEntityQueries
 import whisk.http.ErrorResponse
 import whisk.http.ErrorResponse.{ terminate }
-import spray.routing.RequestContext
-import scala.language.postfixOps
-import whisk.common.LoggingMarkers
+
 
 /**
  * A singleton object which defines the properties that must be present in a configuration
@@ -249,19 +250,30 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
                 val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
                 getEntity(WhiskAction, entityStore, docid, Some {
                     action: WhiskAction =>
-                        val postToLoadBalancer = postInvokeRequest(user.subject, action, env, payload, blocking, result)
+                        val postToLoadBalancer = postInvokeRequest(user.subject, action, env, payload, blocking)
                         onComplete(postToLoadBalancer) {
                             case Success((activationId, None)) =>
+                                // non-blocking invoke or blocking invoke which got queued instead
                                 info(this, "", CONTROLLER_ACTIVATION_DONE)
                                 complete(Accepted, activationId.toJsObject)
-                            case Success((activationId, Some((activationResponse, activationResult)))) =>
+                            case Success((activationId, Some(activation))) =>
+                                // blocking invoke with an activation result
                                 info(this, "", CONTROLLER_BLOCKING_ACTIVATION_DONE)
-                                if (activationResponse.isSuccess) {
-                                    complete(OK, activationResult)
-                                } else if (activationResponse.isWhiskError) {
-                                    complete(InternalServerError, activationResult)
+                                val response = if (result) activation.resultAsJson else activation.toExtendedJson
+
+                                if (activation.response.isSuccess) {
+                                    complete(OK, response)
+                                } else if (activation.response.isApplicationError) {
+                                    // actions that result is ApplicationError status are considered a 'success'
+                                    // and will have an 'error' property in the result - the HTTP status is OK
+                                    // and clients must check the response status if it exists
+                                    // NOTE: response status will not exist in the JSON object if ?result == true
+                                    // and instead clients must check if 'error' is in the JSON
+                                    complete(OK, response)
+                                } else if (activation.response.isContainerError) {
+                                    complete(BadGateway, response)
                                 } else {
-                                    complete(BadGateway, activationResult)
+                                    complete(InternalServerError, response)
                                 }
                             case Failure(t: BlockingInvokeTimeout) =>
                                 info(this, s"[POST] action activation waiting period expired")
@@ -392,8 +404,13 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
      * @param transid a transaction id for logging
      * @return a promise that completes with (ActivationId, Some(WhiskActivation)) if blocking else (ActivationId, None)
      */
-    private def postInvokeRequest(user: Subject, action: WhiskAction, env: Option[Parameters], payload: Option[JsObject], blocking: Boolean, resultOnly: Boolean)(
-        implicit transid: TransactionId): Future[(ActivationId, Option[(ActivationResponse, JsObject)])] = {
+    private def postInvokeRequest(
+        user: Subject,
+        action: WhiskAction,
+        env: Option[Parameters],
+        payload: Option[JsObject],
+        blocking: Boolean)(
+            implicit transid: TransactionId): Future[(ActivationId, Option[WhiskActivation])] = {
         // merge package parameters with action (action parameters supersede), then merge in payload
         val args = { env map { _ ++ action.parameters } getOrElse action.parameters } merge payload
         val message = Message(transid, s"/actions/invoke/${action.namespace}/${action.name}/${action.rev}", user, ActivationId(), args)
@@ -421,10 +438,12 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
                 if (blocking) {
                     val docid = DocId(WhiskEntity.qualifiedName(user.namespace, activationId))
                     val timeout = duration + blockingInvokeGrace
-                    val promise = Promise[(ActivationId, Option[(ActivationResponse, JsObject)])]
+                    val promise = Promise[Option[WhiskActivation]]
                     info(this, s"[POST] action activation will block on result up to $timeout ($duration + $blockingInvokeGrace grace)")
-                    pollLocalForResult(docid.asDocInfo, activationId, resultOnly, promise)
-                    val response = promise.future withTimeout (timeout, new BlockingInvokeTimeout(activationId))
+                    pollLocalForResult(docid.asDocInfo, activationId, promise)
+                    val response = promise.future map {
+                        (activationId, _)
+                    } withTimeout (timeout, new BlockingInvokeTimeout(activationId))
                     response onFailure { case t => promise.tryFailure(t) } // short circuits polling on result
                     response // will either complete with activation or fail with timeout
                 } else Future { (activationId, None) }
@@ -437,16 +456,20 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
      * If this mechanism fails to produce an answer quickly, the future will fail and we back off into using
      * a database operation to obtain the canonical answer.
      */
-    private def pollLocalForResult(docid: DocInfo, activationId: ActivationId, resultOnly: Boolean,
-                                   promise: Promise[(ActivationId, Option[(ActivationResponse, JsObject)])])(implicit transid: TransactionId): Unit = {
+    private def pollLocalForResult(
+        docid: DocInfo,
+        activationId: ActivationId,
+        promise: Promise[Option[WhiskActivation]])(
+            implicit transid: TransactionId): Unit = {
         queryActivationResponse(activationId, transid) map {
-            activation =>
-                val response = if (resultOnly) activation.getResultJson else activation.toExtendedJson
-                promise.trySuccess(activationId, Some((activation.response, response)))
+            activation => promise.trySuccess { Some(activation) }
         } onFailure {
-            case t: Throwable => {
-                pollDbForResult(docid, activationId, resultOnly, promise)
-            }
+            case t: TimeoutException =>
+                info(this, s"[POST] switching to poll db, active ack expired")
+                pollDbForResult(docid, activationId, promise)
+            case t: Throwable =>
+                error(this, s"[POST] switching to poll db, active ack exception: ${t.getMessage}")
+                pollDbForResult(docid, activationId, promise)
         }
     }
 
@@ -456,19 +479,19 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
      * either there is an error in the get, or the promise has completed because it timed out. The promise MUST
      * complete in the caller to terminate the polling.
      */
-    private def pollDbForResult(docid: DocInfo, activationId: ActivationId, resultOnly: Boolean,
-                                promise: Promise[(ActivationId, Option[(ActivationResponse, JsObject)])])(implicit transid: TransactionId): Unit = {
+    private def pollDbForResult(
+        docid: DocInfo,
+        activationId: ActivationId,
+        promise: Promise[Option[WhiskActivation]])(
+            implicit transid: TransactionId): Unit = {
         if (!promise.isCompleted) {
             WhiskActivation.get(activationStore, docid) map {
-                fullActivation =>
-                    val activation = fullActivation.stripLogs
-                    val response = if (resultOnly) activation.getResultJson else activation.toExtendedJson
-                    promise.trySuccess(activationId, Some((activation.response, response)))
+                activation => promise.trySuccess { Some(activation) } // activation may have logs, do not strip them
             } onFailure {
                 case e: NoDocumentException =>
                     Thread.sleep(500)
-                    info(this, s"[POST] action activation not yet timed out, will poll for result")
-                    pollDbForResult(docid, activationId, resultOnly, promise)
+                    debug(this, s"[POST] action activation not yet timed out, will poll for result")
+                    pollDbForResult(docid, activationId, promise)
                 case t: Throwable =>
                     error(this, s"[POST] action activation failed while waiting on result: ${t.getMessage}")
                     promise.tryFailure(t)

--- a/core/dispatcher/src/whisk/core/invoker/Invoker.scala
+++ b/core/dispatcher/src/whisk/core/invoker/Invoker.scala
@@ -270,7 +270,7 @@ class Invoker(
                     val contents = getContainerLogs(con)
                     val activation = makeWhiskActivation(tran, con.isBlackbox, msg, action, payload, response, contents)
                     val res = completeTransaction(tran, activation)
-                    val completeMsg = CompletionMessage(transid, msg.activationId, activation.stripLogs)
+                    val completeMsg = CompletionMessage(transid, activation withoutLogs)
                     producer.send("completed", completeMsg) map { status =>
                         info(this, s"posted completion of activation ${msg.activationId}")
                     }

--- a/tests/src/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActionsApiTests.scala
@@ -422,7 +422,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         Post(s"$collectionPath/${action.name}?blocking=true&result=true") ~> sealRoute(routes(creds)) ~> check {
             status should be(OK)
             val response = responseAs[JsObject]
-            response should be(activation.getResultJson)
+            response should be(activation.resultAsJson)
         }
 
         deleteActivation(activation.docid)


### PR DESCRIPTION
Removed activation id from Message as it is redundant.
Removed method from ActivationResult, moved to WhiskActivation.
Removed unnecessary null check on a value type. Add result extractor and renamed method.
Removed unecessary build dependence.
Simplified promise to (activation id, activation) and consolidated result projection. Also fixed implementation divergence from spec for activations which result in application error status (backlog).
Allow hit under miss in queries for active ack (at most one promise at a time for an activation id).
